### PR TITLE
feat(lib): add utility modules for path, glob, state, and tasks parsing

### DIFF
--- a/.opencode/lib/glob-utils.ts
+++ b/.opencode/lib/glob-utils.ts
@@ -1,0 +1,7 @@
+import picomatch from 'picomatch';
+
+export function matchesScope(normalizedPath: string, allowedScopes: string[]): boolean {
+  return allowedScopes.some(glob => 
+    picomatch.isMatch(normalizedPath, glob, { dot: false })
+  );
+}

--- a/.opencode/lib/path-utils.ts
+++ b/.opencode/lib/path-utils.ts
@@ -1,0 +1,36 @@
+import path from 'path';
+import fs from 'fs';
+import { execSync } from 'child_process';
+
+export function getWorktreeRoot(): string {
+  try {
+    const result = execSync('git rev-parse --show-toplevel', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+    return result.trim();
+  } catch {
+    return process.cwd();
+  }
+}
+
+export function isSymlink(filePath: string): boolean {
+  try {
+    const stats = fs.lstatSync(filePath);
+    return stats.isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+export function isOutsideWorktree(filePath: string, worktreeRoot: string): boolean {
+  const absolutePath = path.resolve(filePath);
+  const relativePath = path.relative(worktreeRoot, absolutePath);
+  return relativePath.startsWith('..');
+}
+
+export function normalizeToRepoRelative(filePath: string, worktreeRoot: string): string {
+  const absolutePath = path.resolve(filePath);
+  const relativePath = path.relative(worktreeRoot, absolutePath);
+  return relativePath.split(path.sep).join('/');
+}

--- a/.opencode/lib/state-utils.ts
+++ b/.opencode/lib/state-utils.ts
@@ -1,0 +1,63 @@
+import lockfile from 'proper-lockfile';
+import writeFileAtomic from 'write-file-atomic';
+import fs from 'fs';
+
+const STATE_DIR = '.opencode/state';
+const STATE_PATH = `${STATE_DIR}/current_context.json`;
+
+export interface State {
+  version: number;
+  activeTaskId: string;
+  activeTaskTitle: string;
+  allowedScopes: string[];
+  startedAt: string;
+  startedBy: string;
+}
+
+export type StateResult = 
+  | { status: 'ok'; state: State }
+  | { status: 'not_found' }
+  | { status: 'corrupted'; error: string };
+
+export async function writeState(state: State): Promise<void> {
+  if (!fs.existsSync(STATE_DIR)) {
+    fs.mkdirSync(STATE_DIR, { recursive: true });
+  }
+  
+  const release = await lockfile.lock(STATE_DIR, { 
+    retries: 5,
+    stale: 10000
+  });
+  try {
+    await writeFileAtomic(STATE_PATH, JSON.stringify(state, null, 2));
+  } finally {
+    await release();
+  }
+}
+
+export function readState(): StateResult {
+  try {
+    if (!fs.existsSync(STATE_PATH)) {
+      return { status: 'not_found' };
+    }
+    
+    const content = fs.readFileSync(STATE_PATH, 'utf-8');
+    const state = JSON.parse(content);
+    
+    if (!state.activeTaskId || !Array.isArray(state.allowedScopes)) {
+      return { status: 'corrupted', error: 'Invalid state schema' };
+    }
+    
+    return { status: 'ok', state };
+  } catch (error) {
+    return { status: 'corrupted', error: (error as Error).message };
+  }
+}
+
+export function clearState(): void {
+  try {
+    if (fs.existsSync(STATE_PATH)) {
+      fs.unlinkSync(STATE_PATH);
+    }
+  } catch { /* noop */ }
+}

--- a/.opencode/lib/tasks-parser.ts
+++ b/.opencode/lib/tasks-parser.ts
@@ -1,0 +1,47 @@
+const TASK_REGEX = /^\* \[([ x])\] ([A-Za-z][A-Za-z0-9_-]*-\d+): (.+?) \(Scope: (.+)\)$/;
+const BACKTICK_SCOPE_REGEX = /`([^`]+)`/g;
+
+export interface ParsedTask {
+  id: string;
+  title: string;
+  scopes: string[];
+  done: boolean;
+}
+
+function parseScopes(scopeStr: string): string[] {
+  const backtickMatches = [...scopeStr.matchAll(BACKTICK_SCOPE_REGEX)];
+  if (backtickMatches.length > 0) {
+    return backtickMatches.map(m => m[1]);
+  }
+  
+  return scopeStr.split(/,\s*/).map(s => s.trim()).filter(Boolean);
+}
+
+export function parseTask(line: string): ParsedTask | null {
+  const match = line.match(TASK_REGEX);
+  if (!match) return null;
+  
+  const [, checkbox, id, title, scopeStr] = match;
+  const scopes = parseScopes(scopeStr);
+  
+  return { id, title, scopes, done: checkbox === 'x' };
+}
+
+export function parseTasksFile(content: string): ParsedTask[] {
+  const lines = content.split('\n');
+  const tasks: ParsedTask[] = [];
+  
+  for (const line of lines) {
+    const trimmed = line.trim();
+    
+    if (trimmed === '') continue;
+    if (trimmed.startsWith('#')) continue;
+    
+    const task = parseTask(trimmed);
+    if (task) {
+      tasks.push(task);
+    }
+  }
+  
+  return tasks;
+}

--- a/__tests__/lib/glob-utils.test.ts
+++ b/__tests__/lib/glob-utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect } from 'bun:test';
+
+describe('glob-utils', () => {
+  describe('matchesScope', () => {
+    test('matches file in glob pattern', async () => {
+      const { matchesScope } = await import('../../.opencode/lib/glob-utils');
+      expect(matchesScope('src/auth/login.ts', ['src/auth/**'])).toBe(true);
+    });
+
+    test('does not match file outside glob pattern', async () => {
+      const { matchesScope } = await import('../../.opencode/lib/glob-utils');
+      expect(matchesScope('src/pay/x.ts', ['src/auth/**'])).toBe(false);
+    });
+
+    test('matches against multiple patterns', async () => {
+      const { matchesScope } = await import('../../.opencode/lib/glob-utils');
+      expect(matchesScope('tests/auth/test.ts', ['src/auth/**', 'tests/**'])).toBe(true);
+    });
+
+    test('returns false for empty scopes array', async () => {
+      const { matchesScope } = await import('../../.opencode/lib/glob-utils');
+      expect(matchesScope('specs/a.md', [])).toBe(false);
+    });
+
+    test('matches exact file pattern', async () => {
+      const { matchesScope } = await import('../../.opencode/lib/glob-utils');
+      expect(matchesScope('README.md', ['README.md'])).toBe(true);
+    });
+
+    test('handles dotfiles based on picomatch defaults', async () => {
+      const { matchesScope } = await import('../../.opencode/lib/glob-utils');
+      expect(matchesScope('.gitignore', ['*'])).toBe(false);
+    });
+  });
+});

--- a/__tests__/lib/path-utils.test.ts
+++ b/__tests__/lib/path-utils.test.ts
@@ -1,0 +1,86 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import path from 'path';
+import fs from 'fs';
+
+const WORKTREE_ROOT = process.cwd();
+
+describe('path-utils', () => {
+  describe('normalizeToRepoRelative', () => {
+    test('converts absolute path to repo-relative path', async () => {
+      const { normalizeToRepoRelative } = await import('../../.opencode/lib/path-utils');
+      const absolutePath = path.join(WORKTREE_ROOT, 'src', 'a.ts');
+      const result = normalizeToRepoRelative(absolutePath, WORKTREE_ROOT);
+      expect(result).toBe('src/a.ts');
+    });
+
+    test('handles relative path input', async () => {
+      const { normalizeToRepoRelative } = await import('../../.opencode/lib/path-utils');
+      const result = normalizeToRepoRelative('src/auth/login.ts', WORKTREE_ROOT);
+      expect(result).toBe('src/auth/login.ts');
+    });
+
+    test('normalizes path separators to POSIX', async () => {
+      const { normalizeToRepoRelative } = await import('../../.opencode/lib/path-utils');
+      const result = normalizeToRepoRelative(path.join('src', 'auth', 'login.ts'), WORKTREE_ROOT);
+      expect(result).toBe('src/auth/login.ts');
+    });
+  });
+
+  describe('isOutsideWorktree', () => {
+    test('returns true for parent directory traversal', async () => {
+      const { isOutsideWorktree } = await import('../../.opencode/lib/path-utils');
+      const result = isOutsideWorktree('../secret.txt', WORKTREE_ROOT);
+      expect(result).toBe(true);
+    });
+
+    test('returns false for path inside worktree', async () => {
+      const { isOutsideWorktree } = await import('../../.opencode/lib/path-utils');
+      const result = isOutsideWorktree('src/a.ts', WORKTREE_ROOT);
+      expect(result).toBe(false);
+    });
+
+    test('returns false for nested path inside worktree', async () => {
+      const { isOutsideWorktree } = await import('../../.opencode/lib/path-utils');
+      const result = isOutsideWorktree('src/auth/deep/file.ts', WORKTREE_ROOT);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getWorktreeRoot', () => {
+    test('returns current directory for git repo', async () => {
+      const { getWorktreeRoot } = await import('../../.opencode/lib/path-utils');
+      const result = getWorktreeRoot();
+      expect(result).toBe(WORKTREE_ROOT);
+    });
+  });
+
+  describe('isSymlink', () => {
+    const symlinkPath = path.join(WORKTREE_ROOT, '__tests__', 'test-symlink');
+    const regularFile = path.join(WORKTREE_ROOT, 'package.json');
+
+    beforeAll(() => {
+      try { fs.symlinkSync(regularFile, symlinkPath); } catch { /* noop */ }
+    });
+
+    afterAll(() => {
+      try { fs.unlinkSync(symlinkPath); } catch { /* noop */ }
+    });
+
+    test('returns true for symlink', async () => {
+      const { isSymlink } = await import('../../.opencode/lib/path-utils');
+      if (fs.existsSync(symlinkPath)) {
+        expect(isSymlink(symlinkPath)).toBe(true);
+      }
+    });
+
+    test('returns false for regular file', async () => {
+      const { isSymlink } = await import('../../.opencode/lib/path-utils');
+      expect(isSymlink(regularFile)).toBe(false);
+    });
+
+    test('returns false for non-existent file', async () => {
+      const { isSymlink } = await import('../../.opencode/lib/path-utils');
+      expect(isSymlink('/nonexistent/path')).toBe(false);
+    });
+  });
+});

--- a/__tests__/lib/state-utils.test.ts
+++ b/__tests__/lib/state-utils.test.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'fs';
+import path from 'path';
+
+const STATE_DIR = '.opencode/state';
+const STATE_PATH = `${STATE_DIR}/current_context.json`;
+
+describe('state-utils', () => {
+  beforeEach(() => {
+    if (fs.existsSync(STATE_PATH)) {
+      fs.unlinkSync(STATE_PATH);
+    }
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(STATE_PATH)) {
+      fs.unlinkSync(STATE_PATH);
+    }
+  });
+
+  describe('writeState and readState', () => {
+    test('writes and reads state correctly', async () => {
+      const { writeState, readState } = await import('../../.opencode/lib/state-utils');
+      
+      const state = {
+        version: 1,
+        activeTaskId: 'Task-1',
+        activeTaskTitle: 'Test Task',
+        allowedScopes: ['src/auth/**'],
+        startedAt: new Date().toISOString(),
+        startedBy: 'test'
+      };
+      
+      await writeState(state);
+      
+      const result = readState();
+      expect(result.status).toBe('ok');
+      if (result.status === 'ok') {
+        expect(result.state.activeTaskId).toBe('Task-1');
+        expect(result.state.allowedScopes).toEqual(['src/auth/**']);
+      }
+    });
+
+    test('returns not_found when state file does not exist', async () => {
+      const { readState } = await import('../../.opencode/lib/state-utils');
+      
+      const result = readState();
+      expect(result.status).toBe('not_found');
+    });
+
+    test('returns corrupted for invalid JSON', async () => {
+      const { readState } = await import('../../.opencode/lib/state-utils');
+      
+      if (!fs.existsSync(STATE_DIR)) {
+        fs.mkdirSync(STATE_DIR, { recursive: true });
+      }
+      fs.writeFileSync(STATE_PATH, '{ invalid json');
+      
+      const result = readState();
+      expect(result.status).toBe('corrupted');
+    });
+
+    test('returns corrupted for missing required fields', async () => {
+      const { readState } = await import('../../.opencode/lib/state-utils');
+      
+      if (!fs.existsSync(STATE_DIR)) {
+        fs.mkdirSync(STATE_DIR, { recursive: true });
+      }
+      fs.writeFileSync(STATE_PATH, JSON.stringify({ version: 1 }));
+      
+      const result = readState();
+      expect(result.status).toBe('corrupted');
+    });
+  });
+
+  describe('clearState', () => {
+    test('deletes state file', async () => {
+      const { writeState, clearState, readState } = await import('../../.opencode/lib/state-utils');
+      
+      const state = {
+        version: 1,
+        activeTaskId: 'Task-1',
+        activeTaskTitle: 'Test',
+        allowedScopes: ['src/**'],
+        startedAt: new Date().toISOString(),
+        startedBy: 'test'
+      };
+      
+      await writeState(state);
+      expect(fs.existsSync(STATE_PATH)).toBe(true);
+      
+      clearState();
+      expect(fs.existsSync(STATE_PATH)).toBe(false);
+      
+      const result = readState();
+      expect(result.status).toBe('not_found');
+    });
+
+    test('does not throw when file does not exist', async () => {
+      const { clearState } = await import('../../.opencode/lib/state-utils');
+      
+      expect(() => clearState()).not.toThrow();
+    });
+  });
+});

--- a/__tests__/lib/tasks-parser.test.ts
+++ b/__tests__/lib/tasks-parser.test.ts
@@ -1,0 +1,101 @@
+import { describe, test, expect } from 'bun:test';
+
+describe('tasks-parser', () => {
+  describe('parseTask', () => {
+    test('parses task with backtick scopes', async () => {
+      const { parseTask } = await import('../../.opencode/lib/tasks-parser');
+      
+      const result = parseTask('* [ ] Task-1: Title (Scope: `src/**`)');
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe('Task-1');
+      expect(result!.title).toBe('Title');
+      expect(result!.scopes).toEqual(['src/**']);
+      expect(result!.done).toBe(false);
+    });
+
+    test('parses task with multiple backtick scopes', async () => {
+      const { parseTask } = await import('../../.opencode/lib/tasks-parser');
+      
+      const result = parseTask('* [ ] Task-2: Auth (Scope: `src/auth/**`, `tests/auth/**`)');
+      expect(result).not.toBeNull();
+      expect(result!.scopes).toEqual(['src/auth/**', 'tests/auth/**']);
+    });
+
+    test('parses task without backticks (lenient mode)', async () => {
+      const { parseTask } = await import('../../.opencode/lib/tasks-parser');
+      
+      const result = parseTask('* [ ] Task-3: Pay (Scope: src/pay/**, tests/pay/**)');
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe('Task-3');
+      expect(result!.scopes).toEqual(['src/pay/**', 'tests/pay/**']);
+    });
+
+    test('parses completed task', async () => {
+      const { parseTask } = await import('../../.opencode/lib/tasks-parser');
+      
+      const result = parseTask('* [x] Task-4: Done (Scope: `a/**`)');
+      expect(result).not.toBeNull();
+      expect(result!.done).toBe(true);
+    });
+
+    test('returns null for invalid format', async () => {
+      const { parseTask } = await import('../../.opencode/lib/tasks-parser');
+      
+      expect(parseTask('not a task')).toBeNull();
+      expect(parseTask('# Header')).toBeNull();
+      expect(parseTask('')).toBeNull();
+    });
+
+    test('handles various TaskID formats', async () => {
+      const { parseTask } = await import('../../.opencode/lib/tasks-parser');
+      
+      expect(parseTask('* [ ] PAY-12: Payment (Scope: `src/**`)')!.id).toBe('PAY-12');
+      expect(parseTask('* [ ] Auth-1: Auth (Scope: `src/**`)')!.id).toBe('Auth-1');
+      expect(parseTask('* [ ] T_ask-99: Test (Scope: `src/**`)')!.id).toBe('T_ask-99');
+    });
+  });
+
+  describe('parseTasksFile', () => {
+    test('parses multiple tasks from content', async () => {
+      const { parseTasksFile } = await import('../../.opencode/lib/tasks-parser');
+      
+      const content = `# Tasks
+
+* [ ] Task-1: First (Scope: \`src/a/**\`)
+* [x] Task-2: Second (Scope: \`src/b/**\`)
+* [ ] Task-3: Third (Scope: \`src/c/**\`)`;
+      
+      const tasks = parseTasksFile(content);
+      expect(tasks).toHaveLength(3);
+      expect(tasks[0].id).toBe('Task-1');
+      expect(tasks[1].done).toBe(true);
+      expect(tasks[2].id).toBe('Task-3');
+    });
+
+    test('skips empty lines and comments', async () => {
+      const { parseTasksFile } = await import('../../.opencode/lib/tasks-parser');
+      
+      const content = `
+# Header comment
+
+* [ ] Task-1: Only (Scope: \`src/**\`)
+
+# Another comment
+`;
+      
+      const tasks = parseTasksFile(content);
+      expect(tasks).toHaveLength(1);
+    });
+
+    test('preserves order', async () => {
+      const { parseTasksFile } = await import('../../.opencode/lib/tasks-parser');
+      
+      const content = `* [ ] Z-1: Last (Scope: \`z/**\`)
+* [ ] A-2: First (Scope: \`a/**\`)`;
+      
+      const tasks = parseTasksFile(content);
+      expect(tasks[0].id).toBe('Z-1');
+      expect(tasks[1].id).toBe('A-2');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `path-utils.ts` - getWorktreeRoot(), isSymlink(), isOutsideWorktree(), normalizeToRepoRelative()
- `glob-utils.ts` - matchesScope() using picomatch
- `state-utils.ts` - writeState(), readState(), clearState() with proper-lockfile
- `tasks-parser.ts` - parseTask(), parseTasksFile() with lenient scope parsing

## Tests
- 33 tests covering all utility functions
- `bun test __tests__/lib/`

## Depends On
- #2 (feature/task0-infrastructure)

## Next PR
`feature/task2-3-custom-tools` (custom tools)