### PR TITLE
fix(kiro): 意味的分析の失敗時に検証プロセスを継続できるように修正

### DIFF
--- a/.opencode/lib/kiro-utils.ts
+++ b/.opencode/lib/kiro-utils.ts
@@ -235,10 +235,15 @@ export async function analyzeKiroGapDeep(featureName: string, changedFiles: stri
     );
 
     // 意味的分析の実行
-    enhanced.semanticAnalysis = await findSemanticGaps(
-      enhanced.extractedRequirements,
-      changedFiles
-    );
+    try {
+      enhanced.semanticAnalysis = await findSemanticGaps(
+        enhanced.extractedRequirements,
+        changedFiles
+      );
+    } catch (error) {
+      enhanced.semanticAnalysis = null;
+      enhanced.gaps.push('意味的分析の実行に失敗しました（Embeddingsの設定や接続を確認してください）');
+    }
 
     if (enhanced.semanticAnalysis && enhanced.semanticAnalysis.gaps.length > 0) {
       enhanced.gaps.push(


### PR DESCRIPTION
- findSemanticGaps の呼び出しを try-catch でラップ
- 失敗時は警告として gaps に追加するよう変更