### PR TITLE
feat(tools): sdd_scaffold_specs を追加 (Issue #62 Phase2-1)

### DIFF
--- a/.opencode/tools/sdd_scaffold_specs.ts
+++ b/.opencode/tools/sdd_scaffold_specs.ts
@@ -1,0 +1,135 @@
+import { tool } from '../lib/plugin-stub';
+import * as fs from 'fs';
+import * as path from 'path';
+
+function getKiroSpecsDir() {
+  const kiroDir = process.env.SDD_KIRO_DIR || '.kiro';
+  return path.resolve(kiroDir, 'specs');
+}
+
+function validateFeatureName(feature: string, baseDir: string) {
+  if (!feature || feature.trim() === '') {
+    throw new Error('無効な機能名: feature は必須です');
+  }
+
+  const validPattern = /^[A-Za-z][A-Za-z0-9._-]*$/;
+  if (!validPattern.test(feature)) {
+    throw new Error('無効な機能名: 半角英字で始まり、英数字・ドット・アンダースコア・ハイフンのみ使用可能です');
+  }
+
+  const resolvedPath = path.resolve(baseDir, feature);
+  
+  if (!resolvedPath.startsWith(baseDir)) {
+    throw new Error('無効な機能名: パストラバーサルが検出されました');
+  }
+
+  return resolvedPath;
+}
+
+export default tool({
+  description: '機能仕様書の雛形（requirements.md, design.md, tasks.md）を生成します',
+  args: {
+    feature: tool.schema.string().describe('機能名（ディレクトリ名として使用。英字開始の英数字記号のみ）'),
+    prompt: tool.schema.string().optional().describe('要件の概要や指示（requirements.mdに追記されます）'),
+    overwrite: tool.schema.boolean().optional().describe('既存のファイルを上書きするかどうか（デフォルト: false）')
+  },
+  async execute({ feature, prompt, overwrite }) {
+    const baseDir = getKiroSpecsDir();
+    
+    let targetDir: string;
+    try {
+      targetDir = validateFeatureName(feature, baseDir);
+    } catch (error: any) {
+      return `エラー: ${error.message}`;
+    }
+
+    if (!fs.existsSync(targetDir)) {
+      try {
+        fs.mkdirSync(targetDir, { recursive: true });
+      } catch (error: any) {
+        return `エラー: ディレクトリ作成に失敗しました (${error.message})`;
+      }
+    }
+
+    const files = [
+      {
+        name: 'requirements.md',
+        content: `# Requirements: ${feature}
+
+## 概要
+${prompt || 'この機能の目的と概要を記述してください。'}
+
+## ユーザーストーリー
+- **役割** <ユーザー>
+- **やりたいこと** <アクション>
+- **理由・メリット** <目的/価値>
+
+## 受入条件 (EARS)
+- **前提** <前提条件>
+- **もし** <トリガー/操作>
+- **ならば** <期待される結果>
+`
+      },
+      {
+        name: 'design.md',
+        content: `# Design: ${feature}
+
+## アーキテクチャ概要
+この機能の技術的な実現方針を記述します。
+
+## コンポーネント設計
+### Mermaid Diagram
+\`\`\`mermaid
+graph TD
+    User -->|Action| ComponentA
+    ComponentA -->|Call| ServiceB
+\`\`\`
+
+## データ構造
+- 主要なインターフェースや型定義
+
+## 依存関係
+- 外部APIやライブラリへの依存
+`
+      },
+      {
+        name: 'tasks.md',
+        content: `# Tasks
+
+* [ ] ${feature}-1: 基本実装 (Scope: \`src/...\`)
+* [ ] ${feature}-2: テスト実装 (Scope: \`__tests__/...\`)
+`
+      }
+    ];
+
+    const results: string[] = [];
+    let skippedCount = 0;
+    let createdCount = 0;
+
+    for (const file of files) {
+      const filePath = path.join(targetDir, file.name);
+      
+      if (fs.existsSync(filePath) && !overwrite) {
+        results.push(`スキップ: ${file.name} (既に存在します)`);
+        skippedCount++;
+        continue;
+      }
+
+      try {
+        fs.writeFileSync(filePath, file.content, 'utf-8');
+        results.push(`作成: ${file.name}`);
+        createdCount++;
+      } catch (error: any) {
+        results.push(`エラー: ${file.name} (${error.message})`);
+      }
+    }
+
+    if (createdCount > 0) {
+      return `✅ 仕様書の雛形を作成しました: ${feature}\n\n${results.join('\n')}`;
+    } else if (skippedCount > 0) {
+      return `⚠️ スキップされました: ${feature}\n\n${results.join('\n')}\n\n既存ファイルを上書きするには、引数 'overwrite: true' を指定してください。`;
+    } else {
+      return `エラー: ファイル生成に失敗しました\n\n${results.join('\n')}`;
+    }
+  }
+});

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ sdd_end_task
 | `sdd_end_task` | 現在のタスクを終了し、状態をクリアします。 |
 | `sdd_show_context` | 現在アクティブなタスク、許可されたスコープ、開始時間を表示します。 |
 | `sdd_validate_gap` | 仕様とコードのギャップ分析、テスト実行、Diagnostics検証を行います。 |
+| `sdd_scaffold_specs` | Kiro形式の仕様書（Requirements/Design/Tasks）の雛形（テンプレート）を生成・初期化します。 |
 
 ## 高度な機能: Kiro 統合 (cc-sdd)
 
@@ -154,6 +155,36 @@ Kiro（cc-sdd）をプロジェクトにセットアップします。
 ```bash
 npx cc-sdd@latest --claude
 ```
+
+### 仕様書テンプレート生成ツール (sdd_scaffold_specs)
+
+Kiro 形式の仕様書テンプレートを一括生成します。
+
+```bash
+sdd_scaffold_specs --feature <name> [--prompt "指示"] [--overwrite true]
+```
+
+- **生成ファイル**:
+  - `.kiro/specs/<feature>/requirements.md`: 要件定義
+  - `.kiro/specs/<feature>/design.md`: 基本設計
+  - `.kiro/specs/<feature>/tasks.md`: タスク分解
+
+- **引数**:
+  - `--feature` (必須): 機能名。英数字記号 `^[A-Za-z][A-Za-z0-9._-]*$` のみ使用可能。
+  - `--prompt` (任意): 生成時の追加指示（コンテキスト）。
+  - `--overwrite` (任意): 既存ファイルを上書きする場合 `true` を指定。
+
+- **使用例**:
+  ```bash
+  # 基本的な生成
+  sdd_scaffold_specs --feature auth-flow
+
+  # 指示を与えて生成
+  sdd_scaffold_specs --feature payment --prompt "Stripeを使用した決済フロー"
+
+  # 強制上書き
+  sdd_scaffold_specs --feature auth-flow --overwrite true
+  ```
 
 ### 仕様駆動ワークフロー
 

--- a/__tests__/tools/sdd_scaffold_specs.test.ts
+++ b/__tests__/tools/sdd_scaffold_specs.test.ts
@@ -1,0 +1,122 @@
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { setupTestState, cleanupTestState } from '../helpers/test-harness';
+
+const TOOL_PATH = '../../.opencode/tools/sdd_scaffold_specs';
+
+describe('sdd_scaffold_specs', () => {
+  let tmpDir: string;
+  let kiroDir: string;
+
+  beforeEach(() => {
+    tmpDir = setupTestState();
+    kiroDir = path.join(tmpDir, '.kiro');
+    if (!fs.existsSync(path.join(kiroDir, 'specs'))) {
+      fs.mkdirSync(path.join(kiroDir, 'specs'), { recursive: true });
+    }
+  });
+
+  afterEach(() => {
+    cleanupTestState();
+  });
+
+  async function runTool(args: any) {
+    const module = await import(TOOL_PATH);
+    return module.default.execute(args, {
+    });
+  }
+
+  it('指定されたfeature名のディレクトリと仕様書テンプレートを作成する', async () => {
+    const feature = 'auth-flow';
+    const result = await runTool({ feature });
+
+    expect(result).toContain(`✅ 仕様書の雛形を作成しました: ${feature}`);
+
+    const specDir = path.join(kiroDir, 'specs', feature);
+    expect(fs.existsSync(specDir)).toBe(true);
+    expect(fs.existsSync(path.join(specDir, 'requirements.md'))).toBe(true);
+    expect(fs.existsSync(path.join(specDir, 'design.md'))).toBe(true);
+    expect(fs.existsSync(path.join(specDir, 'tasks.md'))).toBe(true);
+
+    const reqContent = fs.readFileSync(path.join(specDir, 'requirements.md'), 'utf-8');
+    expect(reqContent).toContain('# Requirements: auth-flow');
+  });
+
+  it('prompt引数が指定された場合、requirements.mdに反映される', async () => {
+    const feature = 'user-profile';
+    const prompt = 'ユーザーがアバター画像をアップロードできる機能';
+    
+    await runTool({ feature, prompt });
+
+    const specDir = path.join(kiroDir, 'specs', feature);
+    const reqContent = fs.readFileSync(path.join(specDir, 'requirements.md'), 'utf-8');
+    
+    expect(reqContent).toContain(prompt);
+  });
+
+  it('既存のファイルがある場合、デフォルトでは上書きしない', async () => {
+    const feature = 'existing-feat';
+    const specDir = path.join(kiroDir, 'specs', feature);
+    fs.mkdirSync(specDir, { recursive: true });
+    
+    const existingContent = 'Existing Content';
+    fs.writeFileSync(path.join(specDir, 'requirements.md'), existingContent);
+    fs.writeFileSync(path.join(specDir, 'design.md'), existingContent);
+    fs.writeFileSync(path.join(specDir, 'tasks.md'), existingContent);
+
+    const result = await runTool({ feature });
+
+    expect(result).toContain('スキップ'); 
+    
+    const content = fs.readFileSync(path.join(specDir, 'requirements.md'), 'utf-8');
+    expect(content).toBe(existingContent);
+  });
+
+  it('overwrite=true の場合、既存ファイルを上書きする', async () => {
+    const feature = 'overwrite-feat';
+    const specDir = path.join(kiroDir, 'specs', feature);
+    fs.mkdirSync(specDir, { recursive: true });
+    
+    fs.writeFileSync(path.join(specDir, 'requirements.md'), 'OLD');
+
+    await runTool({ feature, overwrite: true });
+    
+    const content = fs.readFileSync(path.join(specDir, 'requirements.md'), 'utf-8');
+    expect(content).not.toBe('OLD');
+    expect(content).toContain('# Requirements');
+  });
+
+  it('パス・トラバーサル文字が含まれるfeature名を拒否する', async () => {
+    const badFeatures = [
+      '../hacker',
+      'foo/../../bar',
+      '/etc/passwd',
+      'null\0byte'
+    ];
+
+    for (const feature of badFeatures) {
+      const result = await runTool({ feature });
+      expect(result).toContain('エラー');
+      expect(result).toContain('無効な機能名');
+    }
+  });
+
+  it('feature名に許可されない文字が含まれる場合を拒否する', async () => {
+    const invalidFeatures = [
+      'nested/feature',
+      'back\\slash',
+      '123numberstart',
+      'space name',
+      '日本語',
+      '!',
+    ];
+
+    for (const feature of invalidFeatures) {
+      const result = await runTool({ feature });
+      expect(result).toContain('エラー');
+      expect(result).toContain('無効な機能名');
+    }
+  });
+});

--- a/specs/tasks.md
+++ b/specs/tasks.md
@@ -2,7 +2,7 @@
 
 ## Active Tasks
 
-<!-- 現在進行中のタスクはここに記載 -->
+* [ ] Task-2-1: `sdd_scaffold_specs` ツールとテストの実装 (Scope: `.opencode/tools/sdd_scaffold_specs.ts`, `.opencode/lib/**`, `__tests__/tools/sdd_scaffold_specs.test.ts`, `README.md`)
 
 ## Completed Tasks
 


### PR DESCRIPTION
## 概要
- Issue #62 Phase2-1 として、Kiro仕様書テンプレートを生成する `sdd_scaffold_specs` を追加
- `.kiro/specs/<feature>/` に `requirements.md` / `design.md` / `tasks.md` を雛形生成

## 仕様・挙動
- `feature` は `^[A-Za-z][A-Za-z0-9._-]*$` のみ許可（パストラバーサル対策）
- `overwrite: true` 指定時のみ既存ファイルを上書き

## テスト
- `bun test`

## 関連
- Refs #62