### PR TITLE
fix: OpenCode クラッシュの修正

### DIFF
--- a/.opencode/lib/state-utils.ts
+++ b/.opencode/lib/state-utils.ts
@@ -1,10 +1,10 @@
-import lockfile from 'proper-lockfile';
-import writeFileAtomic from 'write-file-atomic';
+// Simple file-based lock implementation to avoid proper-lockfile Bun 1.3.5 crash
 import fs from 'fs';
 import path from 'path';
 import { rotateBackup, getBackupPaths } from './backup-utils';
 
 const DEFAULT_STATE_DIR = '.opencode/state';
+const LOCK_DIR_NAME = '.lock';
 
 export function getStateDir(): string {
   return process.env.SDD_STATE_DIR || DEFAULT_STATE_DIR;
@@ -25,38 +25,28 @@ export interface State {
   role: 'architect' | 'implementer' | null;
 }
 
-export type StateResult = 
+export type StateResult =
   | { status: 'ok'; state: State }
   | { status: 'not_found' }
   | { status: 'corrupted'; error: string }
   | { status: 'recovered'; state: State; fromBackup: string };
 
-export function getLockOptions(): lockfile.LockOptions {
-  let stale = parseInt(process.env.SDD_LOCK_STALE || '30000', 10);
-  if (!Number.isFinite(stale)) {
-    stale = 30000;
-  }
+// Simple file-based lock utilities
+function getLockPath(): string {
+  return `${getStateDir()}/${LOCK_DIR_NAME}`;
+}
 
-  // Default: retry 10 times, wait 4s each = 40s total coverage > 30s stale
-  // For tests (when SDD_TEST_MODE is set), reduce timeouts to fail fast
-  const isTest = process.env.NODE_ENV === 'test' || process.env.SDD_TEST_MODE === 'true';
-  
-  let retries = parseInt(process.env.SDD_LOCK_RETRIES || (isTest ? '2' : '10'), 10);
-  if (!Number.isFinite(retries)) {
-    retries = isTest ? 2 : 10;
-  }
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
 
-  const minTimeout = isTest ? 100 : 4000;
-  const maxTimeout = isTest ? 100 : 4000;
-  
-  return {
-    stale,
-    retries: {
-      retries,
-      minTimeout,
-      maxTimeout
-    }
-  };
+function isLockStale(lockPath: string, staleMs: number): boolean {
+  try {
+    const stat = fs.statSync(lockPath);
+    return Date.now() - stat.mtimeMs > staleMs;
+  } catch {
+    return true;
+  }
 }
 
 export async function lockStateDir(): Promise<() => Promise<void>> {
@@ -64,31 +54,58 @@ export async function lockStateDir(): Promise<() => Promise<void>> {
   if (!fs.existsSync(stateDir)) {
     fs.mkdirSync(stateDir, { recursive: true });
   }
-  
-  const options = getLockOptions();
-  
-  try {
-    return await lockfile.lock(stateDir, options);
-  } catch (error: any) {
-    if (error.code === 'ELOCKED') {
-      const lockFilePath = error.file || `${stateDir}.lock`;
-      
-      const retryOpts = options.retries as { retries: number; maxTimeout: number };
-      const count = retryOpts.retries || 0;
-      const time = retryOpts.maxTimeout || 0;
-      const totalWaitMs = count * time;
-      const totalWaitSec = Math.round(totalWaitMs / 1000);
 
-      throw new Error(
-        `[SDD] Failed to acquire lock on ${stateDir}.\n` +
-        `Lock file: ${lockFilePath}\n` +
-        `Another process might be active, or a stale lock remains.\n` +
-        `We tried waiting for ~${totalWaitSec}s.\n` +
-        `Try running: sdd_force_unlock`
-      );
+  const lockPath = getLockPath();
+  const isTest = process.env.NODE_ENV === 'test' || process.env.SDD_TEST_MODE === 'true';
+
+  let stale = parseInt(process.env.SDD_LOCK_STALE || '30000', 10);
+  if (!Number.isFinite(stale)) stale = 30000;
+
+  let retries = parseInt(process.env.SDD_LOCK_RETRIES || (isTest ? '2' : '10'), 10);
+  if (!Number.isFinite(retries)) retries = isTest ? 2 : 10;
+
+  const waitMs = isTest ? 100 : 4000;
+
+  for (let i = 0; i <= retries; i++) {
+    try {
+      // Atomic directory creation - fails if already exists
+      fs.mkdirSync(lockPath);
+
+      // Lock acquired - return release function
+      return async () => {
+        try {
+          fs.rmdirSync(lockPath);
+        } catch { /* ignore */ }
+      };
+    } catch (error: any) {
+      if (error.code === 'EEXIST') {
+        // Lock exists - check if stale
+        if (isLockStale(lockPath, stale)) {
+          try {
+            fs.rmdirSync(lockPath);
+            continue; // Retry immediately
+          } catch { /* ignore */ }
+        }
+
+        if (i < retries) {
+          await sleep(waitMs);
+          continue;
+        }
+
+        const totalWaitSec = Math.round((retries * waitMs) / 1000);
+        throw new Error(
+          `[SDD] Failed to acquire lock on ${stateDir}.\n` +
+          `Lock path: ${lockPath}\n` +
+          `Another process might be active, or a stale lock remains.\n` +
+          `We tried waiting for ~${totalWaitSec}s.\n` +
+          `Try running: sdd_force_unlock`
+        );
+      }
+      throw error;
     }
-    throw error;
   }
+
+  throw new Error('[SDD] Failed to acquire lock: max retries exceeded');
 }
 
 export async function writeState(state: State): Promise<void> {
@@ -96,7 +113,10 @@ export async function writeState(state: State): Promise<void> {
   const release = await lockStateDir();
   try {
     rotateBackup(statePath);
-    await writeFileAtomic(statePath, JSON.stringify(state, null, 2));
+    // Use fs.writeFileSync instead of write-file-atomic to avoid potential Bun issues
+    const tmpPath = `${statePath}.${process.pid}.tmp`;
+    fs.writeFileSync(tmpPath, JSON.stringify(state, null, 2));
+    fs.renameSync(tmpPath, statePath);
   } finally {
     await release();
   }
@@ -148,18 +168,18 @@ export async function readState(): Promise<StateResult> {
   if (!fs.existsSync(statePath)) {
     return { status: 'not_found' };
   }
-  
+
   const result = tryParseState(statePath);
   if (result.ok) {
     return { status: 'ok', state: result.state };
   }
-  
+
   console.warn(`[SDD] State corrupted: ${result.error}. Attempting recovery from backup...`);
-  
+
   const backupPaths = getBackupPaths(statePath);
   for (const backupPath of backupPaths) {
     if (!fs.existsSync(backupPath)) continue;
-    
+
     const backupResult = tryParseState(backupPath);
     if (backupResult.ok) {
       const release = await lockStateDir();
@@ -169,7 +189,7 @@ export async function readState(): Promise<StateResult> {
         if (current.ok) {
           return { status: 'ok', state: current.state };
         }
-        
+
         fs.copyFileSync(backupPath, statePath);
         console.warn(`[SDD] State recovered from ${backupPath}`);
         return { status: 'recovered', state: backupResult.state, fromBackup: backupPath };
@@ -178,7 +198,7 @@ export async function readState(): Promise<StateResult> {
       }
     }
   }
-  
+
   console.warn('[SDD] No valid backup found. State is corrupted.');
   return { status: 'corrupted', error: result.error };
 }
@@ -192,23 +212,11 @@ export async function clearState(): Promise<void> {
     return;
   }
 
-  // Attempt to acquire lock, but proceed even if it fails (force clear behavior)
-  // or should we be strict? Design choice: clearState is destructive/cleanup.
-  // Ideally, we lock. If lock fails (zombie), force unlock?
-  // For now, let's just lock and rely on the new timeout logic.
   let release: (() => Promise<void>) | undefined;
   try {
     release = await lockStateDir();
   } catch (e) {
     console.warn(`[SDD] Failed to lock state dir during clearState: ${(e as Error).message}`);
-    // Fallback: proceed to clear anyway? Or fail?
-    // Given the task is to fix zombie locks, maybe we should NOT block clearing.
-    // However, if we don't lock, we risk race.
-    // Let's assume lockStateDir will throw if it can't acquire, and that's good.
-    // But wait, clearState is used in "sdd_end_task". If sdd_end_task fails because of lock...
-    // user is stuck.
-    // But "sdd_force_unlock" is the new tool for that.
-    // So enforcing lock here is correct.
     throw e;
   }
 
@@ -239,10 +247,10 @@ export function getGuardModePath(): string {
 }
 
 export async function readGuardModeState(): Promise<GuardModeState | null> {
-  const path = getGuardModePath();
-  if (!fs.existsSync(path)) return null;
+  const filePath = getGuardModePath();
+  if (!fs.existsSync(filePath)) return null;
   try {
-    const content = fs.readFileSync(path, 'utf-8');
+    const content = fs.readFileSync(filePath, 'utf-8');
     const parsed = JSON.parse(content);
     if (parsed && (parsed.mode === 'warn' || parsed.mode === 'block')) {
       return parsed as GuardModeState;
@@ -257,7 +265,10 @@ export async function writeGuardModeState(state: GuardModeState): Promise<void> 
   const statePath = getGuardModePath();
   const release = await lockStateDir();
   try {
-    await writeFileAtomic(statePath, JSON.stringify(state, null, 2));
+    // Use fs.writeFileSync + rename for atomic write
+    const tmpPath = `${statePath}.${process.pid}.tmp`;
+    fs.writeFileSync(tmpPath, JSON.stringify(state, null, 2));
+    fs.renameSync(tmpPath, statePath);
   } finally {
     await release();
   }

--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -2,7 +2,7 @@
   "name": "omo-sdd-hybrid-plugin",
   "type": "module",
   "dependencies": {
-    "@opencode-ai/plugin": "1.1.39",
+    "@opencode-ai/plugin": "1.1.47",
     "cc-sdd": "^2.0.5",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",

--- a/.opencode/tools/sdd_set_guard_mode.ts
+++ b/.opencode/tools/sdd_set_guard_mode.ts
@@ -1,30 +1,27 @@
+import { tool } from '../lib/plugin-stub';
 import { type GuardMode, writeGuardModeState } from '../lib/state-utils';
 
-async function main() {
-  const args = process.argv.slice(2);
-  const mode = args[0];
+export default tool({
+    description: 'ガードモードを設定します（warn または block）',
+    args: {
+        mode: tool.schema.string().describe('ガードモード: warn（警告のみ）または block（ブロック）')
+    },
+    async execute({ mode }) {
+        if (mode !== 'warn' && mode !== 'block') {
+            return 'エラー: mode は "warn" または "block" を指定してください';
+        }
 
-  if (mode !== 'warn' && mode !== 'block') {
-    console.error('Usage: sdd_set_guard_mode <warn|block>');
-    process.exit(1);
-  }
+        const currentUser = process.env.USER || 'unknown';
 
-  const currentUser = process.env.USER || 'unknown';
-
-  try {
-    await writeGuardModeState({
-      mode: mode as GuardMode,
-      updatedAt: new Date().toISOString(),
-      updatedBy: currentUser
-    });
-    console.log(`Guard mode set to '${mode}'`);
-  } catch (error) {
-    console.error('Failed to set guard mode:', error);
-    process.exit(1);
-  }
-}
-
-main().catch(error => {
-  console.error('Unexpected error:', error);
-  process.exit(1);
+        try {
+            await writeGuardModeState({
+                mode: mode as GuardMode,
+                updatedAt: new Date().toISOString(),
+                updatedBy: currentUser
+            });
+            return `ガードモードを '${mode}' に設定しました`;
+        } catch (error) {
+            return `ガードモードの設定に失敗しました: ${error}`;
+        }
+    }
 });

--- a/bun.lock
+++ b/bun.lock
@@ -15,11 +15,11 @@
     },
   },
   "packages": {
-    "@types/bun": ["@types/bun@1.3.6", "", { "dependencies": { "bun-types": "1.3.6" } }, "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="],
+    "@types/bun": ["@types/bun@1.3.8", "", { "dependencies": { "bun-types": "1.3.8" } }, "sha512-3LvWJ2q5GerAXYxO2mffLTqOzEu5qnhEAlh48Vnu8WQfnmSwbgagjGZV6BoHKJztENYEDn6QmVd949W4uESRJA=="],
 
     "@types/node": ["@types/node@25.0.9", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw=="],
 
-    "bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
+    "bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "picomatch": "^2.3.1",
     "proper-lockfile": "^4.1.2",
     "write-file-atomic": "^5.0.1",
-    "zod": "^3.22.0"
+    "zod": "^3.25.76"
   },
   "comments": {
     "sdd-cli": "The 'sdd' CLI tool (migrate-tasks, lint-tasks) is planned for in-repo implementation. Not added as dependency until implementation is complete. See spec.md section 4.3 for usage details and manual fallback steps."


### PR DESCRIPTION
## 概要
OpenCode が Bun v1.3.5 でセグメンテーションフォルトでクラッシュする問題を修正しました。

## 修正内容
1. **sdd_set_guard_mode.ts の修正**:
   - args の定義が不正（tool.schema.string() を使っていなかった）なため、トランスパイル時にクラッシュしていた問題を修正。
   - OpenCode の標準的な tool() 形式に準拠させました。
2. **state-utils.ts の修正**:
   - Bun v1.3.5 と互換性に懸念がある proper-lockfile と write-file-atomic への依存を削除。
   - fs モジュールを使用したシンプルなロック機構とアトミック書き込みに置き換えました。