### PR TITLE
feat(issue-87): CIでのScope検証機能を追加（Fail-Closedガード）

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,35 @@ EOF
 chmod +x .git/hooks/pre-commit
 ```
 
+### CIでの変更範囲検証（Scope Guard / Issue #87）
+
+`bun run scripts/sdd_ci_validate.ts` は内部で `.opencode/tools/sdd_ci_runner.ts` を実行し、
+**`specs/tasks.md` の Scope（glob）と、git差分で検出した変更ファイルを突合**して検証します。
+Scope外の変更が含まれている場合は **Fail-Closed（CIを失敗）** します。
+
+#### デフォルト挙動
+
+- `specs/**`, `.opencode/**` は Always Allow（Scope突合をスキップして許可）
+- それ以外の変更は、`specs/tasks.md` に定義された Scope のいずれかに一致する必要があります
+
+#### フラグ
+
+`scripts/sdd_ci_validate.ts` は引数を runner に転送できるため、以下のように指定できます。
+
+```bash
+# Always Allow を無効化し、すべての変更が tasks.md の Scope に含まれることを必須化
+bun run scripts/sdd_ci_validate.ts -- --strict
+
+# CIで未追跡ファイル（git管理外）が存在しても失敗しない
+bun run scripts/sdd_ci_validate.ts -- --allow-untracked
+```
+
+- `--strict`:
+  - Always Allow（`specs/**`, `.opencode/**`）を無効化し、これらのパスも Scope に含まれない場合は失敗します。
+- `--allow-untracked`:
+  - CIモードで未追跡ファイル（`git ls-files --others --exclude-standard`）が存在しても失敗しません。
+  - ローカルの pre-commit（staged files 検証）では未追跡ファイル検出は行いません。
+
 ## トラブルシューティング
 
 ### ロック残留（ゾンビロック）の対処

--- a/__tests__/tools/sdd_ci_runner.test.ts
+++ b/__tests__/tools/sdd_ci_runner.test.ts
@@ -1,0 +1,282 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+describe('sdd_ci_runner', () => {
+  let tmpDir: string;
+  let origCwd: string;
+  let origEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-ci-test-'));
+    origCwd = process.cwd();
+    origEnv = { ...process.env };
+
+    fs.mkdirSync(path.join(tmpDir, '.opencode'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, '.opencode', 'tools'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, '.opencode', 'lib'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'specs'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'src'), { recursive: true });
+
+    spawnSync('git', ['init'], { cwd: tmpDir });
+    spawnSync('git', ['config', 'user.email', 'test@example.com'], { cwd: tmpDir });
+    spawnSync('git', ['config', 'user.name', 'Test User'], { cwd: tmpDir });
+
+    fs.writeFileSync(path.join(tmpDir, '.gitignore'), 'node_modules/\n');
+
+    copySourceFiles(tmpDir);
+
+    const initialFile = path.join(tmpDir, 'README.md');
+    fs.writeFileSync(initialFile, '# Test Project\n');
+    spawnSync('git', ['add', '.'], { cwd: tmpDir });
+    spawnSync('git', ['commit', '-m', 'Initial commit'], { cwd: tmpDir });
+  });
+
+  afterEach(() => {
+    process.chdir(origCwd);
+    Object.keys(process.env).forEach(k => {
+      delete process.env[k];
+    });
+    Object.assign(process.env, origEnv);
+
+    if (fs.existsSync(tmpDir)) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  function copySourceFiles(targetDir: string) {
+    const realOpenCodeDir = path.join(origCwd, '.opencode');
+
+    const runnerSrc = path.join(realOpenCodeDir, 'tools', 'sdd_ci_runner.ts');
+    const runnerDst = path.join(targetDir, '.opencode', 'tools', 'sdd_ci_runner.ts');
+    fs.copyFileSync(runnerSrc, runnerDst);
+
+    const stubSrc = path.join(realOpenCodeDir, 'lib', 'plugin-stub.ts');
+    const stubDst = path.join(targetDir, '.opencode', 'lib', 'plugin-stub.ts');
+    fs.copyFileSync(stubSrc, stubDst);
+
+    const tasksMdSrc = path.join(realOpenCodeDir, 'lib', 'tasks_markdown.ts');
+    const tasksMdDst = path.join(targetDir, '.opencode', 'lib', 'tasks_markdown.ts');
+    fs.copyFileSync(tasksMdSrc, tasksMdDst);
+
+    const globUtilsSrc = path.join(realOpenCodeDir, 'lib', 'glob-utils.ts');
+    const globUtilsDst = path.join(targetDir, '.opencode', 'lib', 'glob-utils.ts');
+    fs.copyFileSync(globUtilsSrc, globUtilsDst);
+
+    const realNodeModules = path.join(origCwd, 'node_modules');
+    const nodeModulesLink = path.join(targetDir, 'node_modules');
+    if (!fs.existsSync(nodeModulesLink)) {
+      fs.symlinkSync(realNodeModules, nodeModulesLink, 'dir');
+    }
+
+    const realOpenCodeNodeModules = path.join(origCwd, '.opencode', 'node_modules');
+    const opencodeNodeModulesLink = path.join(targetDir, '.opencode', 'node_modules');
+    if (fs.existsSync(realOpenCodeNodeModules) && !fs.existsSync(opencodeNodeModulesLink)) {
+      fs.symlinkSync(realOpenCodeNodeModules, opencodeNodeModulesLink, 'dir');
+    }
+  }
+
+  async function runCiValidator(args: string[] = []): Promise<{ code: number; output: string }> {
+    const result = spawnSync('bun', ['run', 'tools/sdd_ci_runner.ts', ...args], {
+      cwd: path.join(tmpDir, '.opencode'),
+      encoding: 'utf-8',
+      env: {
+        ...origEnv,
+        SDD_CI_MODE: 'true',
+        NODE_ENV: 'test',
+      },
+    });
+
+    return {
+      code: result.status ?? 1,
+      output: (result.stdout || '') + (result.stderr || ''),
+    };
+  }
+
+  function writeTasks(content: string) {
+    fs.writeFileSync(path.join(tmpDir, 'specs', 'tasks.md'), content);
+  }
+
+  function commitChange(filePath: string, content: string, message: string) {
+    const fullPath = path.join(tmpDir, filePath);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, content);
+    spawnSync('git', ['add', '.'], { cwd: tmpDir });
+    spawnSync('git', ['commit', '-m', message], { cwd: tmpDir });
+  }
+
+  test('許可Scope内の変更のみ: PASS', async () => {
+    writeTasks('* [ ] Task-1: Auth (Scope: `src/auth/**`)');
+    commitChange('src/auth/login.ts', 'export function login() {}', 'Add auth');
+
+    const res = await runCiValidator();
+    expect(res.code).toBe(0);
+    expect(res.output).toContain('Scope Guard: OK');
+  });
+
+  test('Scope外変更を含む: FAIL（Fail-Closed）', async () => {
+    writeTasks('* [ ] Task-1: Auth (Scope: `src/auth/**`)');
+    commitChange('src/database/db.ts', 'export const db = {};', 'Add db');
+
+    const res = await runCiValidator();
+    expect(res.code).toBe(1);
+    expect(res.output).toContain('SDD Scope Guard Violation');
+    expect(res.output).toContain('src/database/db.ts');
+  });
+
+  test('specs/** と .opencode/** の変更: PASS（Always Allow, 非strict）', async () => {
+    writeTasks('* [ ] Task-1: Core (Scope: `src/core/**`)');
+    commitChange('specs/design.md', '# Design', 'Add design doc');
+    commitChange('.opencode/lib/util.ts', 'export {}', 'Add util');
+
+    const res = await runCiValidator();
+    expect(res.code).toBe(0);
+    expect(res.output).toContain('Scope Guard: OK');
+  });
+
+  test('--strict では Always Allow が無効になり、specs/** でもScope外なら FAIL', async () => {
+    writeTasks('* [ ] Task-1: Auth (Scope: `src/auth/**`)');
+    commitChange('specs/design.md', '# Design', 'Add design');
+
+    const res = await runCiValidator(['--strict']);
+    expect(res.code).toBe(1);
+    expect(res.output).toContain('SDD Scope Guard Violation');
+    expect(res.output).toContain('specs/design.md');
+  });
+
+  test('CIモードで未追跡ファイルがある場合: FAIL', async () => {
+    writeTasks('* [ ] Task-1: Auth (Scope: `src/auth/**`)');
+    commitChange('src/auth/login.ts', 'export {}', 'Add auth');
+
+    fs.writeFileSync(path.join(tmpDir, 'untracked.txt'), 'test');
+
+    const res = await runCiValidator();
+    expect(res.code).toBe(1);
+    expect(res.output).toContain('未追跡ファイルが検出されました');
+    expect(res.output).toContain('untracked.txt');
+  });
+
+  test('CIモードで未追跡ファイルがあり --allow-untracked 指定: PASS', async () => {
+    writeTasks('* [ ] Task-1: Auth (Scope: `src/auth/**`)');
+    commitChange('src/auth/login.ts', 'export {}', 'Add auth');
+
+    fs.writeFileSync(path.join(tmpDir, 'untracked.txt'), 'test');
+
+    const res = await runCiValidator(['--allow-untracked']);
+    expect(res.code).toBe(0);
+    expect(res.output).toContain('未追跡ファイルを許可しました');
+  });
+
+  test('複数Scopeのいずれかにマッチすれば PASS', async () => {
+    writeTasks('* [ ] Task-1: Multi (Scope: `src/auth/**`, `src/db/**`)');
+    commitChange('src/auth/login.ts', 'export {}', 'Auth');
+    commitChange('src/db/schema.ts', 'export {}', 'DB');
+
+    const res = await runCiValidator();
+    expect(res.code).toBe(0);
+    expect(res.output).toContain('Scope Guard: OK');
+  });
+
+  test('tasks.md に構文エラーがある場合: FAIL', async () => {
+    writeTasks('* [ ] Broken Task without scope\n* Invalid line format');
+    commitChange('src/auth/login.ts', 'export {}', 'Add auth');
+
+    const res = await runCiValidator();
+    expect(res.code).toBe(1);
+    expect(res.output).toContain('tasks.md Validation Failed');
+  });
+
+  test('tasks.md が存在しない場合: FAIL', async () => {
+    fs.rmSync(path.join(tmpDir, 'specs', 'tasks.md'), { force: true });
+    commitChange('src/auth/login.ts', 'export {}', 'Add auth');
+
+    const res = await runCiValidator();
+    expect(res.code).toBe(1);
+    expect(res.output).toContain('Tasks definition not found');
+  });
+
+  test('初回コミット（HEAD~1 なし）でも動作する', async () => {
+    const testOrigCwd = process.cwd();
+    const newTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-ci-initial-'));
+    fs.mkdirSync(path.join(newTmpDir, '.opencode', 'tools'), { recursive: true });
+    fs.mkdirSync(path.join(newTmpDir, '.opencode', 'lib'), { recursive: true });
+    fs.mkdirSync(path.join(newTmpDir, 'specs'), { recursive: true });
+    fs.mkdirSync(path.join(newTmpDir, 'src', 'auth'), { recursive: true });
+
+    spawnSync('git', ['init'], { cwd: newTmpDir });
+    spawnSync('git', ['config', 'user.email', 'test@example.com'], { cwd: newTmpDir });
+    spawnSync('git', ['config', 'user.name', 'Test User'], { cwd: newTmpDir });
+
+    const realOpenCodeDir = path.join(testOrigCwd, '.opencode');
+    const runnerSrc = path.join(realOpenCodeDir, 'tools', 'sdd_ci_runner.ts');
+    fs.copyFileSync(runnerSrc, path.join(newTmpDir, '.opencode', 'tools', 'sdd_ci_runner.ts'));
+    const stubSrc = path.join(realOpenCodeDir, 'lib', 'plugin-stub.ts');
+    fs.copyFileSync(stubSrc, path.join(newTmpDir, '.opencode', 'lib', 'plugin-stub.ts'));
+    const tasksMdSrc = path.join(realOpenCodeDir, 'lib', 'tasks_markdown.ts');
+    fs.copyFileSync(tasksMdSrc, path.join(newTmpDir, '.opencode', 'lib', 'tasks_markdown.ts'));
+    const globUtilsSrc = path.join(realOpenCodeDir, 'lib', 'glob-utils.ts');
+    fs.copyFileSync(globUtilsSrc, path.join(newTmpDir, '.opencode', 'lib', 'glob-utils.ts'));
+
+    fs.writeFileSync(path.join(newTmpDir, 'specs', 'tasks.md'), '* [ ] Task-1: Auth (Scope: `src/auth/**`, `.opencode/**`, `specs/**`)');
+    fs.writeFileSync(path.join(newTmpDir, 'src', 'auth', 'login.ts'), 'export {}');
+
+    spawnSync('git', ['add', '.'], { cwd: newTmpDir });
+    spawnSync('git', ['commit', '-m', 'Initial commit'], { cwd: newTmpDir });
+
+    const realNodeModules = path.join(testOrigCwd, 'node_modules');
+    fs.symlinkSync(realNodeModules, path.join(newTmpDir, 'node_modules'), 'dir');
+    const realOpenCodeNodeModules = path.join(testOrigCwd, '.opencode', 'node_modules');
+    if (fs.existsSync(realOpenCodeNodeModules)) {
+      fs.symlinkSync(realOpenCodeNodeModules, path.join(newTmpDir, '.opencode', 'node_modules'), 'dir');
+    }
+
+    const result = spawnSync('bun', ['run', 'tools/sdd_ci_runner.ts', '--allow-untracked'], {
+      cwd: path.join(newTmpDir, '.opencode'),
+      encoding: 'utf-8',
+      env: { ...origEnv, SDD_CI_MODE: 'true', NODE_ENV: 'test' },
+    });
+
+    expect(result.status).toBe(0);
+
+    fs.rmSync(newTmpDir, { recursive: true, force: true });
+  });
+
+  test('Globパターン（ワイルドカード）が正しく動作する', async () => {
+    writeTasks('* [ ] Task-1: Components (Scope: `src/components/**/*.tsx`)');
+    commitChange('src/components/Button.tsx', 'export {}', 'Add Button');
+    commitChange('src/components/Input.tsx', 'export {}', 'Add Input');
+
+    const res = await runCiValidator();
+    expect(res.code).toBe(0);
+  });
+
+  test('Globパターンに一致しないファイルは FAIL', async () => {
+    writeTasks('* [ ] Task-1: Components (Scope: `src/components/**/*.tsx`)');
+    commitChange('src/components/util.ts', 'export {}', 'Add util (not .tsx)');
+
+    const res = await runCiValidator();
+    expect(res.code).toBe(1);
+    expect(res.output).toContain('src/components/util.ts');
+  });
+
+  test('複数タスクのScope統合が正しく動作する', async () => {
+    writeTasks(`* [ ] Task-1: Auth (Scope: \`src/auth/**\`)
+* [ ] Task-2: DB (Scope: \`src/db/**\`)`);
+    commitChange('src/auth/login.ts', 'export {}', 'Auth');
+    commitChange('src/db/schema.ts', 'export {}', 'DB');
+
+    const res = await runCiValidator();
+    expect(res.code).toBe(0);
+  });
+
+  test('変更ファイルが存在しない場合でもエラーにならない', async () => {
+    writeTasks('* [ ] Task-1: Auth (Scope: `src/auth/**`)');
+    spawnSync('git', ['add', 'specs'], { cwd: tmpDir });
+    spawnSync('git', ['commit', '-m', 'Add tasks'], { cwd: tmpDir });
+
+    const res = await runCiValidator();
+    expect(res.code).toBe(0);
+  });
+});

--- a/scripts/sdd_ci_validate.ts
+++ b/scripts/sdd_ci_validate.ts
@@ -14,7 +14,8 @@ if (!fs.existsSync(opencodeDir)) {
 console.log('Running SDD CI Validation...');
 
 // Execute the runner inside .opencode context to resolve dependencies
-const result = spawnSync('bun', ['run', 'tools/sdd_ci_runner.ts'], {
+const runnerArgs = process.argv.slice(2);
+const result = spawnSync('bun', ['run', 'tools/sdd_ci_runner.ts', ...runnerArgs], {
   cwd: opencodeDir,
   stdio: 'inherit',
   env: { 

--- a/specs/tasks.md
+++ b/specs/tasks.md
@@ -11,6 +11,7 @@
 * [x] Task-3-2: `sdd_generate_tests` ツールとテストの実装 (Scope: `.opencode/tools/sdd_generate_tests.ts`, `.opencode/lib/**`, `__tests__/tools/sdd_generate_tests.test.ts`, `README.md`)
 * [x] Task-3-3: `sdd_report_bug` ツールとテストの実装（QAがバグ票を起票する） (Scope: `.opencode/tools/sdd_report_bug.ts`, `.opencode/lib/**`, `__tests__/tools/sdd_report_bug.test.ts`, `.opencode/skills/sdd-qa-engineer/SKILL.md`, `README.md`, `.opencode/plugins/sdd-feedback-loop.ts`, `__tests__/plugins/sdd-feedback-loop.test.ts`)
 * [x] Task-3-4: Pre-commit Hook / CI Integration（検証強制） (Scope: `.github/workflows/ci.yml`, `.github/workflows/ci.yaml`, `scripts/sdd_ci_validate.ts`, `.opencode/tools/sdd_ci_runner.ts`, `README.md`)
+* [ ] Task-3-5: Issue #87 対応: CIでのScope検証機能の実装 (Scope: `.opencode/tools/sdd_ci_runner.ts`, `scripts/sdd_ci_validate.ts`, `__tests__/tools/sdd_ci_runner.test.ts`, `README.md`)
 
 ## Completed Tasks
 


### PR DESCRIPTION
## 概要 (Issue #87)

CI（`sdd_ci_runner`）において、`specs/tasks.md` で定義された Scope と `git diff` による変更ファイルを突合し、**Scope 外の変更が含まれている場合に Fail-Closed で失敗する** 仕組みを実装しました。

これまではローカルの `Gatekeeper` が書き込みをブロックしていましたが、CI 側でもこのチェックを二重に行うことで、ローカルでの取りこぼしや誤ったコミット（Vibe Coding の残骸など）を確実に防ぎます。

## 変更点

- **.opencode/tools/sdd_ci_runner.ts**: Scope 検証ロジックを追加
  - `tasks.md` をパースして全タスクの Scope を集約
  - 変更ファイルを `matchesScope` で判定
  - デフォルトでは `specs/**` と `.opencode/**` は Always Allow（Scope 突合なしで許可）
  - `--strict` オプションで Always Allow を無効化可能
  - CI モードのみ未追跡ファイルを検出し、デフォルトで FAIL（`--allow-untracked` で許可）
- **scripts/sdd_ci_validate.ts**: 引数（`--strict` 等）を Runner へ中継するよう修正
- **README.md**: Scope Guard の仕様と `--strict` / `--allow-untracked` の使い方を追記
- **__tests__/tools/sdd_ci_runner.test.ts**: 新規テスト追加（正常系、違反系、フラグ挙動、CI/Localモード等）

## 検証方法

```bash
# 通常実行（Always Allowあり、Scope外変更でFAIL）
bun run scripts/sdd_ci_validate.ts

# 厳格モード（Always Allowなし、全変更がScope内であること必須）
bun run scripts/sdd_ci_validate.ts -- --strict

# CIでの未追跡ファイル許可
bun run scripts/sdd_ci_validate.ts -- --allow-untracked
```

## 影響範囲

- `bun run scripts/sdd_ci_validate.ts` を実行している既存の CI ワークフローや git hook
  - 基本的に既存の正しい変更（Scope 内）であれば影響ありません。
  - `specs/` や `.opencode/` の変更もデフォルト許可されているため、既存の運用を壊す可能性は低いです。