### PR TITLE
Issue #96: isOutsideWorktree の深い階層の非存在パス判定の回帰テスト追加

### DIFF
--- a/.sisyphus/plans/issue-96.md
+++ b/.sisyphus/plans/issue-96.md
@@ -1,0 +1,19 @@
+# Issue #96 対応 作業計画
+
+## ゴール
+- Issue #96 の期待挙動を満たす
+- `bun test` / `bun run build` / `lsp_diagnostics` が通る
+
+## タスク
+- [ ] P1-0a 調査: Issue #96 の内容（背景/期待/受入条件）を整理する
+- [ ] P1-0b 調査: コードベースの該当箇所と変更スコープ候補を洗い出す
+- [ ] P1-1 Specs: Issue #96 作業用タスクを `specs/tasks.md` に追加（Scope定義）
+- [ ] P1-2 実装: Issue #96 の修正を実装する
+- [ ] P1-3 テスト: 再現テスト/回帰テストを追加する
+- [ ] P1-4 検証: `bun test` / `bun run build` / `lsp_diagnostics` を通す
+
+## 影響範囲（想定）
+- `specs/tasks.md`
+- `.opencode/**`
+- `__tests__/**`
+- `README.md`（必要な場合のみ）

--- a/__tests__/lib/path-utils.symlink.test.ts
+++ b/__tests__/lib/path-utils.symlink.test.ts
@@ -158,4 +158,36 @@ describe('path-utils symlink security', () => {
     // Should be considered OUTSIDE worktree
     expect(isOutsideWorktree(newFilePath, WORKTREE_ROOT)).toBe(true);
   });
+
+  test('symlink directory inside -> outside (deep non-existent path)', () => {
+    if (!OUTSIDE_DIR) return;
+
+    const linkPath = path.join(INSIDE_DIR, 'link-to-outside-dir-deep');
+    const targetPath = OUTSIDE_DIR;
+
+    if (!createSymlinkSafe(targetPath, linkPath)) {
+      console.warn('Skipping symlink test due to permission/fs issues');
+      return;
+    }
+
+    const deepFilePath = path.join(linkPath, 'nested', 'deep', 'new-file.txt');
+
+    // Should be considered OUTSIDE worktree
+    expect(isOutsideWorktree(deepFilePath, WORKTREE_ROOT)).toBe(true);
+  });
+
+  test('symlink directory inside -> outside (deep non-existent directory path)', () => {
+    if (!OUTSIDE_DIR) return;
+
+    const linkPath = path.join(INSIDE_DIR, 'link-to-outside-dir-deep-2');
+    const targetPath = OUTSIDE_DIR;
+
+    if (!createSymlinkSafe(targetPath, linkPath)) {
+      return;
+    }
+
+    const deepDirPath = path.join(linkPath, 'nested', 'deep', 'dir');
+    
+    expect(isOutsideWorktree(deepDirPath, WORKTREE_ROOT)).toBe(true);
+  });
 });

--- a/specs/tasks.md
+++ b/specs/tasks.md
@@ -16,6 +16,7 @@
 * [x] Task-3-7: Loggerの短いシークレットのマスキング漏れ再現テスト (Scope: `__tests__/lib/logger_short_secret.test.ts`)
 * [ ] Task-90: Issue #90 対応: テストマトリクスの拡充（symlink・rename・Windows対応） (Scope: `__tests__/lib/**`, `__tests__/plugins/**`, `.opencode/lib/**`, `.sisyphus/notepads/issue-90/**`)
 * [ ] Task-95: Issue #95 対応: worktree外判定で realpath 失敗時(新規作成)の symlink 迂回を防ぐ (Scope: `.opencode/lib/path-utils.ts`, `__tests__/lib/path-utils.symlink.test.ts`)
+* [ ] Task-96: Issue #96 対応: isOutsideWorktree の realpath フォールバック強化 (Scope: `.opencode/lib/path-utils.ts`, `__tests__/lib/path-utils.symlink.test.ts`, `__tests__/lib/path-utils.test.ts`)
 
 
 ## Completed Tasks


### PR DESCRIPTION
## 概要
Issue #96 対応として、`isOutsideWorktree` が深い階層の非存在パス（特に symlink を通じてワークツリー外を指す場合）を正しく判定できることを保証する回帰テストを追加しました。

これは Issue #95 で実施された「realpath 失敗時のフォールバック処理の改善」が、深い階層でも正しく機能することを AC として固定するものです。

## 変更内容
- `__tests__/lib/path-utils.symlink.test.ts`: 深い階層の非存在ファイル/ディレクトリパスに対するテストケースを2件追加
- `specs/tasks.md`: Task-96 を追加
- `.sisyphus/plans/issue-96.md`: 本タスクの作業計画を追加

## 検証内容
以下のコマンドを実行し、追加したテストを含めすべてパスすることを確認しました。
- `bun test`
- `bun run scripts/sdd_ci_validate.ts -- --allow-untracked`

※ `bun run build` はプロジェクトにビルドスクリプトが存在しないため実施していません。

Fixes #96