### PR TITLE
fix(path-utils): Windowsのドライブ/UNCパスおよび大文字小文字の差異に対応 (#104)

### DIFF
--- a/.opencode/lib/path-utils.ts
+++ b/.opencode/lib/path-utils.ts
@@ -97,13 +97,13 @@ export function isOutsideWorktree(filePath: string, worktreeRoot: string): boole
     return true;
   }
   
-  const fileRoot = path.parse(realFilePath).root;
-  const worktreeRootParsed = path.parse(realWorktreeRoot).root;
-  if (fileRoot !== worktreeRootParsed) {
+  const relative = path.relative(realWorktreeRoot, realFilePath);
+  
+  // Windowsなどでルート（ドライブ）が異なる場合、path.relative は絶対パスを返す
+  if (path.isAbsolute(relative)) {
     return true;
   }
   
-  const relative = path.relative(realWorktreeRoot, realFilePath);
   return relative === '..' || relative.startsWith('..' + path.sep);
 }
 

--- a/__tests__/lib/path-utils.windows.test.ts
+++ b/__tests__/lib/path-utils.windows.test.ts
@@ -1,0 +1,55 @@
+import { mock, expect, test, describe } from "bun:test";
+
+mock.module("path", () => {
+  const win32 = require("node:path").win32;
+  return {
+    ...win32,
+    default: win32,
+  };
+});
+
+mock.module("fs", () => {
+  const fs = require("node:fs");
+  const mockedFs = {
+    ...fs,
+    realpathSync: (p: string) => p,
+    lstatSync: (p: string) => ({
+      isSymbolicLink: () => false,
+    }),
+  };
+  return {
+    ...mockedFs,
+    default: mockedFs,
+  };
+});
+
+const { isOutsideWorktree } = require("../../.opencode/lib/path-utils");
+
+describe("isOutsideWorktree (Windows behavior)", () => {
+  const worktreeRoot = "C:\\repo";
+
+  test("should return false for files inside worktree", () => {
+    expect(isOutsideWorktree("C:\\repo\\src\\file.ts", worktreeRoot)).toBe(false);
+  });
+
+  test("should return true for files outside worktree (different drive)", () => {
+    expect(isOutsideWorktree("D:\\repo\\src\\file.ts", worktreeRoot)).toBe(true);
+  });
+
+  test("should return false for case mismatch in drive letter (KNOWN BUG)", () => {
+    expect(isOutsideWorktree("c:\\repo\\src\\file.ts", worktreeRoot)).toBe(false);
+  });
+
+  test("should return false for case mismatch in path", () => {
+    expect(isOutsideWorktree("C:\\REPO\\src\\file.ts", worktreeRoot)).toBe(false);
+  });
+
+  test("should return false for UNC paths with case mismatch", () => {
+    const uncRoot = "\\\\server\\share";
+    expect(isOutsideWorktree("\\\\SERVER\\SHARE\\file.ts", uncRoot)).toBe(false);
+  });
+
+  test("should return true for files truly outside", () => {
+    expect(isOutsideWorktree("C:\\other\\file.ts", worktreeRoot)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #104

## Summary
- `isOutsideWorktree` のロジックを更新（厳密なルートチェックを削除し、`path.relative` による絶対パスベース의 チェックに変更）
- `__tests__/lib/path-utils.windows.test.ts` に回帰テストを追加