### PR TITLE
fix: .opencode/package.json への不足依存関係の追加

### DIFF
--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -4,9 +4,12 @@
   "dependencies": {
     "@opencode-ai/plugin": "1.1.51",
     "cc-sdd": "^2.0.5",
+    "picomatch": "^2.3.1",
+    "proper-lockfile": "^4.1.2",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "unified": "^11.0.5",
-    "unist-util-visit": "^5.1.0"
+    "unist-util-visit": "^5.1.0",
+    "zod": "^3.25.76"
   }
 }


### PR DESCRIPTION
## 概要
プラグインの起動時に必要となる依存関係（picomatch, proper-lockfile, zod）が不足していたため、`.opencode/package.json` に追加しました。

## 変更内容
- `picomatch`, `proper-lockfile`, `zod` を dependencies に追加

## テスト状況
- 既存のテスト `__tests__/tools/sdd_validate_gap_smart_strategy.test.ts` に失敗がありますが、本変更とは無関係であることを確認しています。