### PR TITLE
feat: enable slash commands and register tool exports

### DIFF
--- a/.opencode/index.ts
+++ b/.opencode/index.ts
@@ -2,6 +2,7 @@ import type { Hooks, Plugin } from './lib/plugin-stub.js';
 import gatekeeper from './plugins/sdd-gatekeeper.js';
 import contextInjector from './plugins/sdd-context-injector.js';
 import feedbackLoop from './plugins/sdd-feedback-loop.js';
+import tools from './tools/index.js';
 
 type EventHook = NonNullable<Hooks['event']>;
 type ConfigHook = NonNullable<Hooks['config']>;
@@ -105,6 +106,7 @@ const plugin: Plugin = async (options) => {
     { name: 'sdd-gatekeeper', hooks: results[0] },
     { name: 'sdd-context-injector', hooks: results[1] },
     { name: 'sdd-feedback-loop', hooks: results[2] },
+    { name: 'sdd-tools', hooks: { tool: tools } },
   ];
 
   return mergeHooks(hooksList);

--- a/.opencode/tools/index.ts
+++ b/.opencode/tools/index.ts
@@ -1,0 +1,43 @@
+import sdd_ci_runner from './sdd_ci_runner.js';
+import sdd_end_task from './sdd_end_task.js';
+import sdd_force_unlock from './sdd_force_unlock.js';
+import sdd_generate_tasks from './sdd_generate_tasks.js';
+import sdd_generate_tests from './sdd_generate_tests.js';
+import sdd_kiro from './sdd_kiro.js';
+import sdd_lint_tasks from './sdd_lint_tasks.js';
+import sdd_merge_change from './sdd_merge_change.js';
+import sdd_project_status from './sdd_project_status.js';
+import sdd_reject_change from './sdd_reject_change.js';
+import sdd_report_bug from './sdd_report_bug.js';
+import sdd_request_spec_change from './sdd_request_spec_change.js';
+import sdd_review_pending from './sdd_review_pending.js';
+import sdd_scaffold_specs from './sdd_scaffold_specs.js';
+import sdd_set_guard_mode from './sdd_set_guard_mode.js';
+import sdd_show_context from './sdd_show_context.js';
+import sdd_start_task from './sdd_start_task.js';
+import sdd_sync_kiro from './sdd_sync_kiro.js';
+import sdd_validate_design from './sdd_validate_design.js';
+import sdd_validate_gap from './sdd_validate_gap.js';
+
+export default {
+    sdd_ci_runner,
+    sdd_end_task,
+    sdd_force_unlock,
+    sdd_generate_tasks,
+    sdd_generate_tests,
+    sdd_kiro,
+    sdd_lint_tasks,
+    sdd_merge_change,
+    sdd_project_status,
+    sdd_reject_change,
+    sdd_report_bug,
+    sdd_request_spec_change,
+    sdd_review_pending,
+    sdd_scaffold_specs,
+    sdd_set_guard_mode,
+    sdd_show_context,
+    sdd_start_task,
+    sdd_sync_kiro,
+    sdd_validate_design,
+    sdd_validate_gap,
+};

--- a/package.json
+++ b/package.json
@@ -12,6 +12,40 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
   },
+  "contributes": {
+    "slashCommands": [
+      {
+        "command": "profile",
+        "description": "Architect role: Specification & Design",
+        "tool": {
+          "name": "sdd_kiro",
+          "parameters": {
+            "command": "profile"
+          }
+        }
+      },
+      {
+        "command": "impl",
+        "description": "Implementer role: Coding & Implementation",
+        "tool": {
+          "name": "sdd_kiro",
+          "parameters": {
+            "command": "impl"
+          }
+        }
+      },
+      {
+        "command": "validate",
+        "description": "Reviewer role: Validation & QA",
+        "tool": {
+          "name": "sdd_kiro",
+          "parameters": {
+            "command": "validate-design"
+          }
+        }
+      }
+    ]
+  },
   "scripts": {
     "build": "tsup .opencode/index.ts .opencode/tools/*.ts --format esm,cjs --out-dir dist --clean --splitting",
     "prepublishOnly": "bun run build",


### PR DESCRIPTION
This PR fixes the issue where slash commands were not recognized by Opencode.

Changes:
- Created `.opencode/tools/index.ts` to export all tools.
- Updated `.opencode/index.ts` to register the tools in the plugin hooks.
- Updated `package.json` to add `contributes.slashCommands` definition for `/profile`, `/impl`, and `/validate`.

This ensures that the tools are properly registered and accessible via slash commands in the OpenCode environment.