### PR TITLE
chore: release 0.0.62 with slash commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yohi/omo-sdd-hybrid",
-  "version": "0.0.1",
+  "version": "0.0.62",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bumping version to 0.0.62 to ensure the slash commands contribution is included in the published package.
Previous release 0.0.61 seemed to miss the package.json update or was built from an older commit.