### PR TITLE
fix: replace package.json contributes with .opencode/commands/*.md

### DIFF
--- a/.opencode/commands/impl.md
+++ b/.opencode/commands/impl.md
@@ -1,0 +1,5 @@
+---
+description: Implementer role: Coding & Implementation
+---
+By using the available tool `sdd_kiro`, execute the `impl` command.
+Argument: `{"command": "impl"}`

--- a/.opencode/commands/profile.md
+++ b/.opencode/commands/profile.md
@@ -1,0 +1,5 @@
+---
+description: Architect role: Specification & Design
+---
+By using the available tool `sdd_kiro`, execute the `profile` command.
+Argument: `{"command": "profile"}`

--- a/.opencode/commands/validate.md
+++ b/.opencode/commands/validate.md
@@ -1,0 +1,5 @@
+---
+description: Reviewer role: Validation & QA
+---
+By using the available tool `sdd_kiro`, execute the `validate-design` command.
+Argument: `{"command": "validate-design"}`

--- a/package.json
+++ b/package.json
@@ -12,40 +12,6 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
   },
-  "contributes": {
-    "slashCommands": [
-      {
-        "command": "profile",
-        "description": "Architect role: Specification & Design",
-        "tool": {
-          "name": "sdd_kiro",
-          "parameters": {
-            "command": "profile"
-          }
-        }
-      },
-      {
-        "command": "impl",
-        "description": "Implementer role: Coding & Implementation",
-        "tool": {
-          "name": "sdd_kiro",
-          "parameters": {
-            "command": "impl"
-          }
-        }
-      },
-      {
-        "command": "validate",
-        "description": "Reviewer role: Validation & QA",
-        "tool": {
-          "name": "sdd_kiro",
-          "parameters": {
-            "command": "validate-design"
-          }
-        }
-      }
-    ]
-  },
   "scripts": {
     "build": "tsup .opencode/index.ts .opencode/tools/*.ts --format esm,cjs --out-dir dist --clean --splitting",
     "prepublishOnly": "bun run build",


### PR DESCRIPTION
PR #130 was merged before the Markdown command files were pushed. This PR executes the switch to Markdown-based slash commands, which is the correct way to distribute commands in OpenCode.