### PR TITLE
chore: ignore OpenCode error logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ bun.lock
 dist/
 build/
 *.log
+*.err
 *.tsbuildinfo
 
 # IDE


### PR DESCRIPTION
Adds *.err to .gitignore to prevent accidental commit of error logs.