### PR TITLE
feat: チャット欄のスラッシュコマンド展開機能

### DIFF
--- a/.opencode/plugins/sdd-command-handler.ts
+++ b/.opencode/plugins/sdd-command-handler.ts
@@ -130,7 +130,8 @@ const SddCommandHandler: Plugin = async (ctx) => {
                             body: { message: errorMsg, variant: 'error', duration: 4000 }
                         }).catch(console.warn);
                     }
-                    message.content = '';
+                    // 元のメッセージを保持してエラーをトーストで通知済み
+                    return;
                 }
                 return;
             }


### PR DESCRIPTION
チャット欄に入力されたスラッシュコマンド（例: `/profile`）を、対応するプロンプトテンプレートに展開してAIに渡す機能を追加しました。

これにより、ユーザーは長いプロンプトを入力することなく、短いコマンドでAIのロールを切り替えたり、特定のタスクを開始したりできるようになります。