### PR TITLE
fix(tools): npmインストール時にプロンプトファイルがブロックされる問題を修正

### DIFF
--- a/.opencode/tools/sdd_kiro.ts
+++ b/.opencode/tools/sdd_kiro.ts
@@ -202,8 +202,17 @@ export default tool({
             for (let i = 0; i < 5; i++) {
               const candidate = path.join(searchDir, '.opencode/prompts/profile.md');
               if (fs.existsSync(candidate)) {
+                // node_modules内にある場合のみパッケージファイルとして扱う
+                const resolvedCandidate = path.resolve(candidate);
+                const nodeModulesPattern = path.sep + 'node_modules' + path.sep;
+                if (resolvedCandidate.includes(nodeModulesPattern)) {
+                  profilePath = candidate;
+                  isFromPackage = true;
+                  break;
+                }
+                // node_modules外のファイルは通常のセキュリティチェック対象
                 profilePath = candidate;
-                isFromPackage = true;
+                isFromPackage = false;
                 break;
               }
               
@@ -212,8 +221,17 @@ export default tool({
               if (fs.existsSync(opencodeDir) && fs.statSync(opencodeDir).isDirectory()) {
                 const p = path.join(opencodeDir, 'prompts/profile.md');
                 if (fs.existsSync(p)) {
+                  // node_modules内にある場合のみパッケージファイルとして扱う
+                  const resolvedP = path.resolve(p);
+                  const nodeModulesPattern = path.sep + 'node_modules' + path.sep;
+                  if (resolvedP.includes(nodeModulesPattern)) {
+                    profilePath = p;
+                    isFromPackage = true;
+                    break;
+                  }
+                  // node_modules外のファイルは通常のセキュリティチェック対象
                   profilePath = p;
-                  isFromPackage = true;
+                  isFromPackage = false;
                   break;
                 }
               }


### PR DESCRIPTION
## 概要
npmパッケージとしてインストールされた環境において、`/profile` コマンド実行時にプロンプトファイル（profile.md）がプロジェクトルート外として誤ってブロックされる問題を修正しました。

## 関連Issue
- fix #なし

## 変更内容
- `sdd_kiro.ts` のパス解決ロジックに `isFromPackage` フラグを導入
- ローカルにプロンプトファイルが存在せず、パッケージ内部から解決された場合はセキュリティチェック（プロジェクトルート外判定）をスキップするように変更

## 動作確認手順
1. 本プラグインを別のプロジェクトにnpmインストール
2. `/profile` コマンドを実行
3. キャッシュディレクトリ内の `profile.md` が正常に読み込まれることを確認

## チェックリスト
- [x] タイトルを [Conventional Commits](https://www.conventionalcommits.org/ja/v1.0.0/) に従ったものにした
- [x] ローカルでテストが通ることを確認した
- [x] ドキュメントを更新した（必要な場合）