### PR TITLE
feat: 要件定義生成時に .gitignore 作成タスクを自動追加

### DIFF
--- a/.opencode/tools/sdd_generate_tasks.ts
+++ b/.opencode/tools/sdd_generate_tasks.ts
@@ -133,6 +133,9 @@ export default tool({
     let tasksContent = `# Tasks\n\n`;
     let taskCount = 1;
 
+    // プロジェクト初期化タスク: .gitignore の作成・更新を常に最初に配置
+    tasksContent += `* [ ] ${feature}-${taskCount++}: .gitignore の作成・更新 (Scope: \`.gitignore\`)\n`;
+
     if (criteria.length > 0) {
       for (const c of criteria) {
         tasksContent += `* [ ] ${feature}-${taskCount++}: 実装: ${c} (Scope: \`src/**\`, \`__tests__/**\`)\n`;
@@ -146,9 +149,8 @@ export default tool({
     }
 
     if (criteria.length === 0 && components.length === 0) {
-      tasksContent += `* [ ] ${feature}-1: 基本実装 (Scope: \`src/...\`)\n`;
-      tasksContent += `* [ ] ${feature}-2: テスト実装 (Scope: \`__tests__/...\`)\n`;
-      taskCount = 3;
+      tasksContent += `* [ ] ${feature}-${taskCount++}: 基本実装 (Scope: \`src/...\`)\n`;
+      tasksContent += `* [ ] ${feature}-${taskCount++}: テスト実装 (Scope: \`__tests__/...\`)\n`;
     }
 
     tasksContent += `* [ ] ${feature}-${taskCount++}: ドキュメント更新 (Scope: \`.kiro/specs/${feature}/**\`)\n`;

--- a/.opencode/tools/sdd_scaffold_specs.ts
+++ b/.opencode/tools/sdd_scaffold_specs.ts
@@ -122,8 +122,9 @@ ${prompt || 'この機能の目的と概要を記述してください。'}
         name: 'tasks.md',
         content: `# Tasks
 
-* [ ] ${feature}-1: 基本実装 (Scope: \`src/...\`)
-* [ ] ${feature}-2: テスト実装 (Scope: \`__tests__/...\`)
+* [ ] ${feature}-1: .gitignore の作成・更新 (Scope: \`.gitignore\`)
+* [ ] ${feature}-2: 基本実装 (Scope: \`src/...\`)
+* [ ] ${feature}-3: テスト実装 (Scope: \`__tests__/...\`)
 `
       }
     ];

--- a/__tests__/tools/sdd_generate_tasks.test.ts
+++ b/__tests__/tools/sdd_generate_tasks.test.ts
@@ -51,6 +51,7 @@ describe('sdd_generate_tasks', () => {
     
     const content = fs.readFileSync(tasksPath, 'utf-8');
     expect(content).toContain('# Tasks');
+    expect(content).toContain(`${feature}-1: .gitignore の作成・更新 (Scope: \`.gitignore\`)`);
     expect(content).toContain(`基本実装 (Scope: \`src/...\`)`);
   });
 
@@ -125,10 +126,11 @@ describe('sdd_generate_tasks', () => {
     const tasksPath = path.join(kiroDir, 'specs', feature, 'tasks.md');
     const content = fs.readFileSync(tasksPath, 'utf-8');
 
-    expect(content).toContain(`smart-feature-1: 実装: ログインができること (Scope: \`src/**\`, \`__tests__/**\`)`);
-    expect(content).toContain(`smart-feature-2: 実装: ログアウトができること (Scope: \`src/**\`, \`__tests__/**\`)`);
-    expect(content).toContain(`smart-feature-3: コンポーネント実装: LoginForm (Scope: \`src/**\`)`);
-    expect(content).toContain(`smart-feature-4: コンポーネント実装: LogoutButton (Scope: \`src/**\`)`);
-    expect(content).toContain(`smart-feature-5: ドキュメント更新 (Scope: \`.kiro/specs/smart-feature/**\`)`);
+    expect(content).toContain(`smart-feature-1: .gitignore の作成・更新 (Scope: \`.gitignore\`)`);
+    expect(content).toContain(`smart-feature-2: 実装: ログインができること (Scope: \`src/**\`, \`__tests__/**\`)`);
+    expect(content).toContain(`smart-feature-3: 実装: ログアウトができること (Scope: \`src/**\`, \`__tests__/**\`)`);
+    expect(content).toContain(`smart-feature-4: コンポーネント実装: LoginForm (Scope: \`src/**\`)`);
+    expect(content).toContain(`smart-feature-5: コンポーネント実装: LogoutButton (Scope: \`src/**\`)`);
+    expect(content).toContain(`smart-feature-6: ドキュメント更新 (Scope: \`.kiro/specs/smart-feature/**\`)`);
   });
 });


### PR DESCRIPTION
## 概要
`/profile` コマンドによる要件定義およびタスク生成時に、プロジェクトの初期化作業として `.gitignore` の作成・更新タスクを常にリストの最初に追加するように変更しました。

## 関連Issue
- なし

## 変更内容
- `.opencode/tools/sdd_generate_tasks.ts`: スマート生成ロジックにおいて、全タスクの先頭に `.gitignore` タスクを挿入し、以降のタスク番号を自動インクリメントするように修正。また、フォールバック時のタスク番号重複バグを修正。
- `.opencode/tools/sdd_scaffold_specs.ts`: 仕様書テンプレート（`tasks.md`）の初期内容に `.gitignore` タスクを `feature-1` として追加。
- `__tests__/tools/sdd_generate_tasks.test.ts`: タスク番号のオフセット変更（+1）に伴うテスト期待値の更新。

## 動作確認手順
1. `sdd_kiro init --feature test-feat` を実行し、生成された `.kiro/specs/test-feat/tasks.md` の先頭に `.gitignore` タスクがあることを確認。
2. `sdd_kiro tasks --feature test-feat` を実行し、既存の要件から生成されるタスクの先頭にも同様のタスクが含まれることを確認。
3. `bun test __tests__/tools/sdd_generate_tasks.test.ts` がパスすることを確認。

## チェックリスト
- [x] タイトルを [Conventional Commits](https://www.conventionalcommits.org/ja/v1.0.0/) に従ったものにした
- [x] ローカルでテストが通ることを確認した
- [x] ドキュメントを更新した（必要な場合）