### PR TITLE
fix: sdd_kiro コマンドの出力にドキュメント内容を含めるように改善

### DIFF
--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -2,7 +2,7 @@
   "name": "omo-sdd-hybrid-plugin",
   "type": "module",
   "dependencies": {
-    "@opencode-ai/plugin": "1.1.57",
+    "@opencode-ai/plugin": "1.1.59",
     "cc-sdd": "^2.0.5",
     "picomatch": "^2.3.1",
     "proper-lockfile": "^4.1.2",


### PR DESCRIPTION
## 概要
`sdd_kiro` (requirements, design, tasks) の実行結果に、作成・生成されたファイルの内容を直接含めるように変更しました。これにより、AIエージェントがバリデーション結果を見落としたり、別途ファイルを読み取る手間を省き、確実にユーザーへ整合性チェックの結果を報告できるように改善しました。

## 関連Issue
- fix #なし

## 変更内容
- **.opencode/tools/sdd_kiro.ts**:
    - `requirements`, `design`, `tasks` 各コマンドの成功時の戻り値に、生成されたファイルの内容を付加するように変更。
    - `requirements` において、Phase B（タスク未開始状態）での `validate-gap` 実行時に `validateGapInternal` を直接呼び出すことで、Stateチェックによるエラー（アクティブなタスクがありません）を回避。
- **.opencode/package.json**:
    - `@opencode-ai/plugin` を `1.1.56` から `1.1.59` へアップデート。

## 動作確認手順
1. `sdd_kiro requirements` または `design` を実行。
2. 出力の末尾に「### 作成されたドキュメント」として内容が含まれていることを確認。
3. `bun test __tests__/tools/sdd_kiro.test.ts` が通過することを確認。

## チェックリスト
- [x] タイトルを [Conventional Commits](https://www.conventionalcommits.org/ja/v1.0.0/) に従ったものにした
- [x] ローカルでテストが通ることを確認した
- [x] ドキュメントを更新した（必要な場合）