### PR TITLE
feat: /finalize コマンドを追加し、仕様確定フローを統合

### DIFF
--- a/.opencode/lib/builtin-commands/definitions/finalize.ts
+++ b/.opencode/lib/builtin-commands/definitions/finalize.ts
@@ -1,0 +1,14 @@
+import { BuiltinCommand } from "../types";
+
+export const finalizeCommand: BuiltinCommand = {
+    name: "finalize",
+    description: "Architect role: Finalize specs & Prepare for Translation",
+    argumentHint: "[feature]",
+    template: `
+<command-instruction>
+By using the available tool \`sdd_kiro\`, execute the \`finalize\` command.
+Target feature: "{{feature}}"
+(If the feature is "(not specified)", omit the feature argument)
+</command-instruction>
+  `.trim()
+};

--- a/.opencode/lib/builtin-commands/index.ts
+++ b/.opencode/lib/builtin-commands/index.ts
@@ -1,12 +1,14 @@
 import { profileCommand } from "./definitions/profile.js";
 import { implCommand } from "./definitions/impl.js";
 import { validateCommand } from "./definitions/validate.js";
+import { finalizeCommand } from "./definitions/finalize.js";
 import { BuiltinCommand } from "./types.js";
 
 export const builtinCommands: Record<string, BuiltinCommand> = {
     [profileCommand.name]: profileCommand,
     [implCommand.name]: implCommand,
     [validateCommand.name]: validateCommand,
+    [finalizeCommand.name]: finalizeCommand,
 };
 
 export function getBuiltinCommand(name: string): BuiltinCommand | undefined {

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Kiroツール (`.kiro/`) とSDD (`specs/`) を組み合わせた理想的な開�
 | `/profile` | **Architect** | 仕様策定・設計フェーズ。インタビュー形式で要件を収集し、EARS記法の初期化プロファイルを生成します。 |
 | `/impl` | **Implementer** | 実装フェーズ。スコープを厳守し、Vibe Coding を回避しながらコーディングします。 |
 | `/validate` | **Reviewer** | 検証フェーズ。仕様と実装の乖離（Gap）を厳格に分析します。 |
+| `/finalize` | **Architect** | 仕様確定・翻訳準備フェーズ。仕様書の整合性を検証し、英語への翻訳準備を行います。 |
 | `/guard` | **Admin** | Gatekeeperのモード（warn/block/disabled）を切り替えます。 |
 
 #### 💡 高度な使い方 (Advanced Usage)

--- a/specs/tasks.md
+++ b/specs/tasks.md
@@ -6,3 +6,4 @@
 * [x] docs-gitignore-1: .gitignore設定の追記 (Scope: `README.md`)
 * [x] docs-update-1: ドキュメントの更新 (Scope: `AGENTS.md`, `README.md`, `.opencode/tools/sdd_ci_runner.ts`)
 * [x] fix-ci-runner-log-1: sdd_ci_runner.ts のログ出力にソース種別（scope.md/tasks.md）を正しく反映する (Scope: `.opencode/tools/sdd_ci_runner.ts`)
+* [x] feat-finalize-command-1: finalize implementation (Scope: `.opencode/**`, `specs/tasks.md`, `README.md`)


### PR DESCRIPTION
## 概要
`/finalize` スラッシュコマンドを追加し、`sdd_kiro finalize` コマンドへのショートカットを提供します。

## 関連Issue
- なし

## 変更内容
- `.opencode/lib/builtin-commands/definitions/finalize.ts`: コマンド定義の実装
- `.opencode/lib/builtin-commands/index.ts`: コマンドの登録
- `README.md`: コマンド一覧への追加
- `specs/tasks.md`: タスク完了の記録

## 動作確認手順
1. `/finalize <feature-name>` を実行し、Architectロールとして `sdd_kiro finalize` が呼び出されることを確認

## チェックリスト
- [x] タイトルを [Conventional Commits](https://www.conventionalcommits.org/ja/v1.0.0/) に従ったものにした
- [x] ローカルでテストが通ることを確認した
- [x] ドキュメントを更新した